### PR TITLE
fix(core): fix an edge case for split_off operation for RrbVec

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -345,6 +345,9 @@ impl<T: Clone + Debug> RrbVec<T> {
 
                         right.tail = new_tail;
                         right.tail_len = new_tail_len;
+
+                        // in case if tail is exactly BRANCH_FACTOR long, we should push it to the tree
+                        right.push_tail()
                     } else if right.tree.len() < BRANCH_FACTOR {
                         // root is leaf, but it is not fully dense
                         // hence, some of the values should be redistributed to the actual leaf

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -266,6 +266,21 @@ macro_rules! make_tests {
             }
 
             #[test]
+            fn interleaving_push_split_off_push_operations() {
+                let mut vec_one = $vec::new();
+
+                for i in 0..(BRANCH_FACTOR * BRANCH_FACTOR) {
+                    vec_one.push(i);
+                }
+
+                let mut vec_two = vec_one.split_off(BRANCH_FACTOR * BRANCH_FACTOR - BRANCH_FACTOR);
+                vec_two.push(0xbeef);
+
+                assert_eq!(vec_one.len(), BRANCH_FACTOR * BRANCH_FACTOR - BRANCH_FACTOR);
+                assert_eq!(vec_two.len(), BRANCH_FACTOR + 1);
+            }
+
+            #[test]
             fn interleaving_different_operations_must_maintain_correct_internal_state_for_var_sizes_4() {
                 interleaving_different_operations_must_maintain_correct_internal_state(4);
             }


### PR DESCRIPTION
There is an edge case that brakes the `push` operation on `RrbVec`. Here are the steps to reproduce it:
- Create a new `RrbVec` instance exactly of the `BRANCH_FACTOR * BRANCH_FACTOR` size.
- Split it exactly at the following index: `BRANCH_FACTOR * BRANCH_FACTOR - BRANCH_FACTOR`.
- Try pushing a new item onto the new (right-hand side) vector.

A simple example for a vector that has a branching factor of 4:
- The in-memory representation of the following vector is going to be a complete and full tree: `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]`.
- Trying to split it at index 12 will produce two new vectors: `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]` and `[12, 13, 14, 15]`.

The right hand size vector will have a full tail. The bug was that the tail was not pushed onto tree when full. When trying to push an ordinary item, `16` for example, it will overflow the vector and cause a panic.